### PR TITLE
Instating Bib from pymarc.Record instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,32 @@ with open ('marc.mrc', "rb") as marcfile:
 		print(bib.dewey_shortened())
 ```
 
+In certain scenarios it may be convinient to instate `Bib` directly from an instance of `pymarc.Record`. This can be accomplished using `pymarc_record_to_local_bib()`:
+
+```python
+from pymarc import Record
+from bookops_marc.bib import pymarc_record_to_local_bib
+
+# pymarc Record instance
+record = Record()
+bib = pymarc_record_to_local_bib(record, "bpl")
+bib.remove_unsupported_subjects()
+```
+
 Python 3.8 and up.
 
 ## Version
-> 0.7.0
+> 0.8.0
 
 ## Changelog
+### [0.8.0] - 2022-08-15
+#### Added
++ `bib.pymarc_record_to_local_bib()` method to instage `Bib` instance from `pymarc.Record` instance
+
+#### Changed
++ added basic normalization to `library` parameter passed to `Bib` class
++ `stub_marc` test fixture renamed to `stub_bib`
+
 ### [0.7.0] - 2022-04-16
 #### Added
 + remove_unsupported_subjects() that deletes subject tags (6xx) which are not supported by BookOps (NYPL & BPL CAT)
@@ -74,6 +94,7 @@ Python 3.8 and up.
 #### Added
 + a method for retrieving branch call number as `pymarc.Field`
 
+[0.8.0]: https://github.com/BookOps-CAT/bookops-marc/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/BookOps-CAT/bookops-marc/compare/v0.6.0...0.7.0
 [0.6.1]: https://github.com/BookOps-CAT/bookops-marc/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/BookOps-CAT/bookops-marc/compare/0.5.0...v0.6.0

--- a/bookops_marc/bib.py
+++ b/bookops_marc/bib.py
@@ -541,3 +541,22 @@ class Bib(Record):
                 except AttributeError:
                     pass
         return None
+
+
+def pymarc_record_to_local_bib(record: Record, library: str) -> Bib:
+    """
+    Converts an instance of `pymarc.Record` to `bookops_marc.Bib`
+
+    Args:
+        record:                 `pymarc.Record` instance
+        library:                'bpl' or 'nypl'
+
+    Returns:
+        `bookops_marc.bib.Bib` instance
+    """
+    if isinstance(record, Record):
+        bib = Bib(library=library)
+        bib.leader = record.leader
+        bib.fields = record.fields[:]
+
+        return bib

--- a/bookops_marc/bib.py
+++ b/bookops_marc/bib.py
@@ -140,9 +140,6 @@ def shorten_dewey(class_mark: str, digits_after_period: int = 4) -> str:
 class Bib(Record):
     """
     A class for representing local MARC record.
-    This implementation fixes pymarc.Record bug (?) which unable accessing
-    current position in the iterator (overwrites pymarc.Record's
-    __iter__ and __next__ methods).
     """
 
     def __init__(
@@ -166,7 +163,10 @@ class Bib(Record):
             file_encoding,
         )
 
-        self.library = library
+        if isinstance(library, str):
+            self.library = library.lower()
+        else:
+            self.library = library
 
     def __iter__(self):
         self.pos = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,41 @@
 import pytest
 
-from pymarc import Field
+from pymarc import Field, Record
 
 from bookops_marc import Bib
 
 
 @pytest.fixture
-def stub_marc():
+def stub_pymarc_record():
+    record = Record()
+    record.leader = "02866pam  2200517 i 4500"
+    record.add_field(Field(tag="008", data="190306s2017    ht a   j      000 1 hat d"))
+    record.add_field(
+        Field(
+            tag="100",
+            indicators=["1", " "],
+            subfields=["a", "Adams, John,", "e", "author."],
+        )
+    )
+    record.add_field(
+        Field(
+            tag="245",
+            indicators=["1", "4"],
+            subfields=["a", "The foo /", "c", "by John Adams."],
+        )
+    )
+    record.add_field(
+        Field(
+            tag="264",
+            indicators=[" ", "1"],
+            subfields=["a", "Bar :", "b", "New York,", "c", "2021"],
+        )
+    )
+    return record
+
+
+@pytest.fixture
+def stub_bib():
     bib = Bib()
     bib.leader = "02866pam  2200517 i 4500"
     bib.add_field(Field(tag="008", data="190306s2017    ht a   j      000 1 hat d"))


### PR DESCRIPTION
+ adds `bib.pymarc_record_to_local_bib()` method allowing to convert `pymarc.Record` instance into `Bib` instance
+ `stub_marc` fixture renamed to `stub_bib` 
+ adds `stub_pymarc_record` fixture