### PR TITLE
Adds a method to parse Sierra bib format code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ with open ('marc.mrc', "rb") as marcfile:
 	reader = SierraBibReader(marcfile)
 	for bib in reader:
 		print(bib.sierra_bib_id_normalized())
+		print(bib.sierra_bib_format())
 		print(bib.branch_call_no())
 		print(bib.orders())
 		print(bib.main_entry())
@@ -49,6 +50,7 @@ Python 3.8 and up.
 ### [0.8.0] - 2022-08-15
 #### Added
 + `bib.pymarc_record_to_local_bib()` method to instage `Bib` instance from `pymarc.Record` instance
++ `sierra_bib_format()` method in `Bib` class that returns 998$d of Sierra record
 
 #### Changed
 + added basic normalization to `library` parameter passed to `Bib` class

--- a/bookops_marc/bib.py
+++ b/bookops_marc/bib.py
@@ -478,6 +478,15 @@ class Bib(Record):
         """
         return self.leader[6]  # type: ignore
 
+    def sierra_bib_format(self) -> Optional[str]:
+        """
+        Returns Sierra bib format fixed field code
+        """
+        try:
+            return self["998"]["d"].strip()
+        except (TypeError, AttributeError):
+            return None
+
     def sierra_bib_id(self) -> Optional[str]:
         """
         Retrieves Sierra bib # from the 907 MARC tag

--- a/tests/test_bib.py
+++ b/tests/test_bib.py
@@ -123,6 +123,20 @@ def test_normalize_order_number():
     assert normalize_order_number(".o28876714") == 2887671
 
 
+def test_sierra_bib_format_missing_tag(stub_bib):
+    assert stub_bib.sierra_bib_format() is None
+
+
+def test_sierra_bib_format_missing_subfield(stub_bib):
+    stub_bib.add_field(Field(tag="998", subfields=["a", "foo"]))
+    assert stub_bib.sierra_bib_format() is None
+
+
+def test_sierra_bib_format(stub_bib):
+    stub_bib.add_field(Field(tag="998", subfields=["a", "foo", "d", "x  "]))
+    assert stub_bib.sierra_bib_format() == "x"
+
+
 def test_sierra_bib_id_missing_tag(stub_bib):
     assert stub_bib.sierra_bib_id() is None
 


### PR DESCRIPTION
Fulfills #5 
Adds `sierra_bib_format()` to `Bib` class that returns normalized 998$d (Sierra fixed field bibliographic format code)