### PR TITLE
Bib updates

### DIFF
--- a/tests/test_bib.py
+++ b/tests/test_bib.py
@@ -14,12 +14,12 @@ from bookops_marc.errors import BookopsMarcError
 
 
 def test_sierra_bib_format_missing_tag(stub_bib):
-    assert stub_bib.sierra_bib_format() is None
+    assert stub_bib.sierra_bib_format is None
 
 
 def test_sierra_bib_format_missing_subfield(stub_bib):
     stub_bib.add_field(Field(tag="998", subfields=[Subfield(code="a", value="foo")]))
-    assert stub_bib.sierra_bib_format() is None
+    assert stub_bib.sierra_bib_format is None
 
 
 def test_sierra_bib_format(stub_bib):
@@ -28,11 +28,11 @@ def test_sierra_bib_format(stub_bib):
             tag="998", subfields=[Subfield(code="a", value="foo"), Subfield("d", "x  ")]
         )
     )
-    assert stub_bib.sierra_bib_format() == "x"
+    assert stub_bib.sierra_bib_format == "x"
 
 
 def test_sierra_bib_id_missing_tag(stub_bib):
-    assert stub_bib.sierra_bib_id() is None
+    assert stub_bib.sierra_bib_id is None
 
 
 def test_sierra_bib_id(stub_bib):
@@ -46,7 +46,7 @@ def test_sierra_bib_id(stub_bib):
             ],
         )
     )
-    assert stub_bib.sierra_bib_id() == "b225444884"
+    assert stub_bib.sierra_bib_id == "b225444884"
 
 
 @pytest.mark.parametrize(
@@ -76,7 +76,7 @@ def test_sierra_bib_id(stub_bib):
     ],
 )
 def test_sierra_bib_id_missing_subfield(stub_bib, field, expectation):
-    assert stub_bib.sierra_bib_id() is None
+    assert stub_bib.sierra_bib_id is None
 
 
 def test_sierra_bib_id_missing_value(stub_bib):
@@ -87,7 +87,7 @@ def test_sierra_bib_id_missing_value(stub_bib):
             subfields=[Subfield(code="a", value="")],
         )
     )
-    assert stub_bib.sierra_bib_id() is None
+    assert stub_bib.sierra_bib_id is None
 
 
 def test_sierra_bib_id_normalized(stub_bib):
@@ -101,11 +101,11 @@ def test_sierra_bib_id_normalized(stub_bib):
             ],
         )
     )
-    assert stub_bib.sierra_bib_id_normalized() == "22544488"
+    assert stub_bib.sierra_bib_id_normalized == "22544488"
 
 
 def test_sierra_bib_id_normalized_missing_tag(stub_bib):
-    assert stub_bib.sierra_bib_id_normalized() is None
+    assert stub_bib.sierra_bib_id_normalized is None
 
 
 @pytest.mark.parametrize(
@@ -146,12 +146,12 @@ def test_sierra_bib_id_normalized_missing_tag(stub_bib):
 def test_branch_call_no(stub_bib, arg1, arg2, arg3, expectation):
     stub_bib.library = arg1
     stub_bib.add_field(Field(tag=arg2, indicators=Indicators(" ", " "), subfields=arg3))
-    assert stub_bib.branch_call_no() == expectation
+    assert stub_bib.branch_call_no == expectation
 
 
 def test_audience_missing_008(stub_bib):
     stub_bib.remove_fields("008")
-    assert stub_bib.audience() is None
+    assert stub_bib.audience is None
 
 
 @pytest.mark.parametrize(
@@ -183,7 +183,7 @@ def test_audience(stub_bib, arg1, arg2, expectation):
     s[6] = arg1
     s[7] = arg2
     stub_bib.leader = "".join(s)
-    assert stub_bib.audience() == expectation
+    assert stub_bib.audience == expectation
 
 
 @pytest.mark.parametrize(
@@ -206,12 +206,11 @@ def test_created_date(stub_bib, arg, expectation):
             ],
         )
     )
-    # print(type(stub_bib.created_date()))
-    assert stub_bib.created_date() == expectation
+    assert stub_bib.created_date == expectation
 
 
 def test_created_date_missing_field(stub_bib):
-    stub_bib.created_date() is None
+    stub_bib.created_date is None
 
 
 def test_cataloging_date(stub_bib):
@@ -225,15 +224,15 @@ def test_cataloging_date(stub_bib):
             ],
         )
     )
-    assert stub_bib.cataloging_date() == datetime(2021, 8, 17).date()
+    assert stub_bib.cataloging_date == datetime(2021, 8, 17).date()
 
 
 def test_cataloging_date_exception(stub_bib):
-    assert stub_bib.cataloging_date() is None
+    assert stub_bib.cataloging_date is None
 
 
 def test_control_number_missing_001(stub_bib):
-    assert stub_bib.control_number() is None
+    assert stub_bib.control_number is None
 
 
 @pytest.mark.parametrize(
@@ -241,15 +240,15 @@ def test_control_number_missing_001(stub_bib):
 )
 def test_control_number(arg, expectation, stub_bib):
     stub_bib.add_field(Field(tag="001", data=arg))
-    assert stub_bib.control_number() == expectation
+    assert stub_bib.control_number == expectation
 
 
 def test_record_type(stub_bib):
-    assert stub_bib.record_type() == "a"
+    assert stub_bib.record_type == "a"
 
 
 def test_physical_description_no_300_tag(stub_bib):
-    assert stub_bib.physical_description() is None
+    assert stub_bib.physical_description is None
 
 
 @pytest.mark.parametrize(
@@ -265,15 +264,15 @@ def test_main_entry(stub_bib, tags, expectation):
     stub_bib.remove_fields("100", "245")
     for t in tags:
         stub_bib.add_field(Field(tag=t, subfields=[Subfield(code="a", value="foo")]))
-    main_entry = stub_bib.main_entry()
-    assert type(main_entry) is Field
+    main_entry = stub_bib.main_entry
+    assert isinstance(main_entry, Field)
     assert main_entry.tag == expectation
 
 
 def test_main_entry_exception(stub_bib):
     stub_bib.remove_fields("100", "245")
     with pytest.raises(BookopsMarcError) as exc:
-        stub_bib.main_entry()
+        stub_bib.main_entry
 
     assert "Incomplete MARC record: missing the main entry." in str(exc.value)
 
@@ -316,7 +315,7 @@ def test_normalize_oclc_control_number_no_defined_library(stub_bib):
 
 
 def test_dewey_no_082(stub_bib):
-    assert stub_bib.dewey() is None
+    assert stub_bib.dewey is None
 
 
 @pytest.mark.parametrize(
@@ -346,7 +345,7 @@ def test_dewey_normalization(stub_bib, arg, expectation):
             subfields=[Subfield(code="a", value=arg)],
         )
     )
-    assert stub_bib.dewey() == expectation
+    assert stub_bib.dewey == expectation
 
 
 def test_dewey_lc_selected(stub_bib):
@@ -371,7 +370,7 @@ def test_dewey_lc_selected(stub_bib):
             subfields=[Subfield(code="a", value="909.12")],
         )
     )
-    assert stub_bib.dewey() == "909.12"
+    assert stub_bib.dewey == "909.12"
 
 
 def test_dewey_other_agency_selected(stub_bib):
@@ -389,7 +388,7 @@ def test_dewey_other_agency_selected(stub_bib):
             subfields=[Subfield(code="a", value="909./092")],
         )
     )
-    assert stub_bib.dewey() == "909.092"
+    assert stub_bib.dewey == "909.092"
 
 
 @pytest.mark.parametrize(
@@ -426,7 +425,7 @@ def test_dewey_shortened(stub_bib, mock_960, arg, expectation):
     mock_960.subfields = new_subfields
     mock_960.add_subfield(code="t", value=arg)
     stub_bib.add_field(mock_960)
-    assert stub_bib.dewey_shortened() == expectation
+    assert stub_bib.dewey_shortened == expectation
 
 
 def test_dewey_shortened_missing_dewey(stub_bib, mock_960):
@@ -438,16 +437,16 @@ def test_dewey_shortened_missing_dewey(stub_bib, mock_960):
         )
     )
     stub_bib.add_field(mock_960)
-    assert stub_bib.dewey_shortened() is None
+    assert stub_bib.dewey_shortened is None
 
 
 def test_languages_none_008(stub_bib):
     stub_bib.remove_fields("008")
-    assert stub_bib.languages() == []
+    assert stub_bib.languages == []
 
 
 def test_languages_only_008_present(stub_bib):
-    assert stub_bib.languages() == ["hat"]
+    assert stub_bib.languages == ["hat"]
 
 
 def test_languages_multiple(stub_bib):
@@ -462,11 +461,11 @@ def test_languages_multiple(stub_bib):
             ],
         )
     )
-    assert stub_bib.languages() == ["hat", "eng", "spa"]
+    assert stub_bib.languages == ["hat", "eng", "spa"]
 
 
 def test_lccn_missing_010(stub_bib):
-    assert stub_bib.lccn() is None
+    assert stub_bib.lccn is None
 
 
 def test_lccn_missing_sub_a(stub_bib):
@@ -477,7 +476,7 @@ def test_lccn_missing_sub_a(stub_bib):
             subfields=[Subfield(code="z", value="foo")],
         )
     )
-    assert stub_bib.lccn() is None
+    assert stub_bib.lccn is None
 
 
 @pytest.mark.parametrize(
@@ -496,32 +495,32 @@ def test_lccn(arg, expectation, stub_bib):
             subfields=[Subfield(code="a", value=arg), Subfield(code="b", value="foo")],
         )
     )
-    assert stub_bib.lccn() == expectation
+    assert stub_bib.lccn == expectation
 
 
 def test_form_of_item_not_present(stub_bib):
     stub_bib.leader = "#" * 6 + "x" + "#" * 18
     stub_bib["008"].data = "#" * 23 + "f" + "#" * 10
-    assert stub_bib.form_of_item() is None
+    assert stub_bib.form_of_item is None
 
 
 def test_form_of_item_missing_008_tag(stub_bib):
     stub_bib.remove_fields("008")
-    assert stub_bib.form_of_item() is None
+    assert stub_bib.form_of_item is None
 
 
 @pytest.mark.parametrize("arg", ["a", "c", "d", "i", "j", "m", "o", "p", "t"])
 def test_form_of_item_in_pos_23(arg, stub_bib):
     stub_bib.leader = "#" * 6 + arg + "#" * 18
     stub_bib["008"].data = "#" * 23 + "f" + "#" * 10
-    assert stub_bib.form_of_item() == "f"
+    assert stub_bib.form_of_item == "f"
 
 
 @pytest.mark.parametrize("arg", ["e", "f", "g", "k"])
 def test_form_of_item_in_pos_29(arg, stub_bib):
     stub_bib.leader = "#" * 6 + arg + "#" * 18
     stub_bib["008"].data = "#" * 29 + "o" + "#" * 14
-    assert stub_bib.form_of_item() == "o"
+    assert stub_bib.form_of_item == "o"
 
 
 def test_oclc_nos_001_and_035(stub_bib):
@@ -531,7 +530,7 @@ def test_oclc_nos_001_and_035(stub_bib):
     stub_bib.add_field(Field(tag="035", subfields=[Subfield("a", "(OCoLC)123456789")]))
     stub_bib.add_field(Field(tag="035", subfields=[Subfield("a", "12345")]))
 
-    assert stub_bib.oclc_nos() == {"001": "1234567890", "035": "123456789"}
+    assert stub_bib.oclc_nos == {"001": "1234567890", "035": "123456789"}
 
 
 def test_oclc_nos_991_only(stub_bib):
@@ -540,14 +539,14 @@ def test_oclc_nos_991_only(stub_bib):
     stub_bib.add_field(Field(tag="035", subfields=[Subfield("a", "wlo000001")]))
     stub_bib.add_field(Field(tag="991", subfields=[Subfield("y", "12345678")]))
 
-    assert stub_bib.oclc_nos() == {"991": "12345678"}
+    assert stub_bib.oclc_nos == {"991": "12345678"}
 
 
 def test_oclc_nos_001_only(stub_bib):
     stub_bib.add_field(Field(tag="001", data="12345678"))
     stub_bib.add_field(Field(tag="003", data="OCoLC"))
     stub_bib.add_field(Field(tag="035", subfields=[Subfield("z", "foo123")]))
-    assert stub_bib.oclc_nos() == {"001": "12345678"}
+    assert stub_bib.oclc_nos == {"001": "12345678"}
 
 
 @pytest.mark.parametrize("arg", [1, "foo"])
@@ -613,7 +612,7 @@ def test_orders_reverse_sort(stub_bib, mock_960):
 
 
 def test_overdrive_number_missing_037(stub_bib):
-    assert stub_bib.overdrive_number() is None
+    assert stub_bib.overdrive_number is None
 
 
 def test_overdrive_number_missing_sub_a(stub_bib):
@@ -624,7 +623,7 @@ def test_overdrive_number_missing_sub_a(stub_bib):
             subfields=[Subfield(code="z", value="foo")],
         )
     )
-    assert stub_bib.overdrive_number() is None
+    assert stub_bib.overdrive_number is None
 
 
 @pytest.mark.parametrize(
@@ -651,7 +650,7 @@ def test_overdrive_number(arg, expectation, stub_bib):
             ],
         )
     )
-    assert stub_bib.overdrive_number() == expectation
+    assert stub_bib.overdrive_number == expectation
 
 
 @pytest.mark.parametrize(
@@ -916,7 +915,7 @@ def test_subjects_lc(stub_bib):
             subfields=[Subfield(code="a", value="Spam.")],
         )
     )
-    lc_subjects = stub_bib.subjects_lc()
+    lc_subjects = stub_bib.subjects_lc
     assert len(lc_subjects) == 2
     assert lc_subjects[0].subfields == [
         Subfield(code="a", value="Doe, John"),
@@ -926,12 +925,12 @@ def test_subjects_lc(stub_bib):
 
 
 def test_suppressed_missing_998(stub_bib):
-    assert stub_bib.suppressed() is False
+    assert stub_bib.suppressed is False
 
 
 def test_suppressed_missing_998_e(stub_bib):
     stub_bib.add_field(Field(tag="998", subfields=[Subfield(code="a", value="foo")]))
-    assert stub_bib.suppressed() is False
+    assert stub_bib.suppressed is False
 
 
 @pytest.mark.parametrize(
@@ -949,11 +948,11 @@ def test_suppressed_missing_998_e(stub_bib):
 )
 def test_suppressed(stub_bib, arg, expectation):
     stub_bib.add_field(Field(tag="998", subfields=[Subfield(code="e", value=arg)]))
-    assert stub_bib.suppressed() == expectation
+    assert stub_bib.suppressed == expectation
 
 
 def test_upc_number_missing_024(stub_bib):
-    assert stub_bib.upc_number() is None
+    assert stub_bib.upc_number is None
 
 
 def test_upc_number_missing_sub_a(stub_bib):
@@ -964,7 +963,7 @@ def test_upc_number_missing_sub_a(stub_bib):
             subfields=[Subfield(code="z", value="foo")],
         )
     )
-    assert stub_bib.upc_number() is None
+    assert stub_bib.upc_number is None
 
 
 def test_upc_number_other_number(stub_bib):
@@ -978,7 +977,7 @@ def test_upc_number_other_number(stub_bib):
             ],
         )
     )
-    assert stub_bib.upc_number() is None
+    assert stub_bib.upc_number is None
 
 
 @pytest.mark.parametrize(
@@ -1002,7 +1001,7 @@ def test_upc_number(arg, expectation, stub_bib):
             subfields=[Subfield(code="a", value=arg), Subfield(code="b", value="foo")],
         )
     )
-    assert stub_bib.upc_number() == expectation
+    assert stub_bib.upc_number == expectation
 
 
 @pytest.mark.parametrize("arg", ["bpl", "nypl", None])
@@ -1014,7 +1013,7 @@ def test_Bib_classmethod_pymarc_record_to_local_bib(stub_pymarc_record, arg):
     assert bib.library == arg
 
     # bib methods
-    assert str(bib.main_entry()) == "=100  1\\$aAdams, John,$eauthor."
+    assert str(bib.main_entry) == "=100  1\\$aAdams, John,$eauthor."
 
 
 @pytest.mark.parametrize("arg", ["bpl", "nypl", None])


### PR DESCRIPTION
 - Changed `pymarc_record_to_local_bib` function to `classmethod` within `Bib` class
 - Removed `#type: ignore` comments from `Bib` class and refactored to handle type errors
 - Changed certain `Bib` methods to properties to match how `Pymarc` with similar parts of a `Record` object. These new properties include:
   - `audience`
   - `branch_call_no`
   - `branch_call_no_field`
   - `cataloging_date`
   - `control_number`
   - `created_date`
   - `dewey`
   - `dewey_shortened`
   - `form_of_item`
   - `languages`
   - `lccn`
   - `main_entry`
   - `oclc_nos`
   - `overdrive_number`
   - `physical_description`
   - `record_type`
   - `sierra_bib_format`
   - `sierra_bib_id`
   - `sierra_bib_id_normalized`
   - `subjects_lc`
   - `suppressed`
   - `upc_number`