### PR TITLE
Order model updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ from bookops_marc import SierraBibReader
 with open('marc.mrc', "rb") as marcfile:
 	reader = SierraBibReader(marcfile)
 	for bib in reader:
-		print(bib.sierra_bib_id_normalized())
-		print(bib.sierra_bib_format())
-		print(bib.branch_call_no())
-		print(bib.orders())
-		print(bib.main_entry())
-		print(bib.form_of_item())
-		print(bib.dewey())
-		print(bib.dewey_shortened())
+		print(bib.sierra_bib_id_normalized)
+		print(bib.sierra_bib_format)
+		print(bib.branch_call_no)
+		print(bib.orders)
+		print(bib.main_entry)
+		print(bib.form_of_item)
+		print(bib.dewey)
+		print(bib.dewey_shortened)
 ```
 
-In certain scenarios it may be convinient to instate `Bib` directly from an instance of `pymarc.Record`. This can be accomplished using `pymarc_record_to_local_bib()`:
+In certain scenarios it may be convenient to instantiate a `Bib` directly from an instance of `pymarc.Record`. This can be accomplished using the `Bib.pymarc_record_to_local_bib()` classmethod:
 
 ```python
 from pymarc import Record
@@ -37,14 +37,14 @@ from bookops_marc.bib import pymarc_record_to_local_bib
 
 # pymarc Record instance
 record = Record()
-bib = pymarc_record_to_local_bib(record, "bpl")
+bib = Bib.pymarc_record_to_local_bib(record, "bpl")
 bib.remove_unsupported_subjects()
 ```
 
 Python 3.8 and up.
 
 ## Version
-> 0.10.0
+> 0.11.0
 
 ## Changelog
 ### [0.10.0] - 2024-03-16

--- a/bookops_marc/local_values.py
+++ b/bookops_marc/local_values.py
@@ -98,5 +98,5 @@ def normalize_date(order_date: str) -> Optional[date]:
             return datetime.strptime(order_date[:8], "%m-%d-%y").date()
         else:
             return datetime.strptime(order_date[:10], "%m-%d-%Y").date()
-    except ValueError:
+    except (ValueError, TypeError):
         return None

--- a/bookops_marc/models.py
+++ b/bookops_marc/models.py
@@ -12,10 +12,56 @@ from .local_values import normalize_date
 
 class Order:
     """
-    A class to represent an Order record
+    A class to represent an `Order` record from a pair of MARC fields.
+    Attributes are computed from a MARC 960 field and the following field
+    its tag is 961.
+
+    Attributes:
+        audn:
+            a list of audience codes from the third character of the
+            location code
+        branches:
+            a list of branch codes from the first two characters of the
+            location code
+        copies:
+            an integer representing the number of copies on an order
+            from subfield 'o'.
+        created:
+            the date the order was created as a datetime.date object
+            from subfield 'q'
+        form:
+            the format of the materials being ordered from subfield 'g'.
+        lang:
+            the language of the materials being ordered from subfield 'w'.
+        locs:
+            a list of location codes from subfield 't'
+        oid:
+            the normalized order id as an integer from subfield 'z'
+        shelves:
+            a list of shelf locations from the fourth and fifth characters
+            of the location code
+        status:
+            the order's status from subfield 'm'
+        venNotes:
+            if the record's 960 field is followed by a 961 field, the vendor
+            notes as a string from subfield 'h' of the 961 field
     """
 
     def __init__(self, field: Field, following_field: Optional[Field]) -> None:
+        """
+        An `Order` object is instantiated from 1-2 `pymarc.Field` objects. These
+        fields are non-public attributes for the class and all other attributes
+        are computed from these fields.
+
+        Args:
+            field:
+                an instance of `pymarc.Field`
+            following_field:
+                either an instance of `pymarc.Field` or `None`. This is the
+                field that follows the 960 field used to instantiate an `Order`
+                object. If the 960 field was the last field in the record
+                then following_field is None.
+        """
         self._field = field
         self._following_field = following_field
 

--- a/bookops_marc/models.py
+++ b/bookops_marc/models.py
@@ -10,34 +10,6 @@ from pymarc import Field
 from .local_values import normalize_date
 
 
-class Item:
-    """
-    A class to represent an Item record
-    """
-
-    def __init__(self, field: Field) -> None:
-        self.agency = self._get_non_repeatable_subfield(field, "h")
-        self.barcode = self._get_non_repeatable_subfield(field, "i")
-        self.call_no = self._get_non_repeatable_subfield(field, "a")
-        self.call_tag = self._get_non_repeatable_subfield(field, "z")
-        self.item_id = self._get_non_repeatable_subfield(field, "y")
-        self.item_message = self._get_non_repeatable_subfield(field, "u")
-        self.location = self._get_non_repeatable_subfield(field, "l")
-        self.opac_message = self._get_non_repeatable_subfield(field, "m")
-        self.price = self._get_non_repeatable_subfield(field, "p")
-        self.type = self._get_non_repeatable_subfield(field, "t")
-        self.vendor_code = self._get_non_repeatable_subfield(field, "v")
-        self.volume = self._get_non_repeatable_subfield(field, "c")
-
-    def _get_non_repeatable_subfield(self, field: Field, code: str) -> Optional[str]:
-        subfields = field.get_subfields(code)
-        if len(subfields) > 1:
-            raise ValueError(f"Subfield {code} is non-repeatable.")
-        for subfield in subfields:
-            return subfield
-        return None
-
-
 class Order:
     """
     A class to represent an Order record

--- a/bookops_marc/models.py
+++ b/bookops_marc/models.py
@@ -16,19 +16,51 @@ class Order:
     """
 
     def __init__(self, field: Field, following_field: Optional[Field]) -> None:
-        self.copies: Optional[int] = int(field.get(code="o", default=0))
-        self.created: Optional[date] = normalize_date(field.get(code="q"))
-        self.form: Optional[str] = field.get(code="g")
-        self.lang: Optional[str] = field.get(code="w")
-        self.locs: List[str] = self._get_location_codes(field)
-        self.oid: int = self._normalize_order_number(field)
-        self.status: Optional[str] = field.get(code="m")
-        self.venNotes: Optional[str] = self._get_venNotes(following_field)
+        self._field = field
+        self._following_field = following_field
 
-    def _get_location_codes(self, field: Field) -> List[str]:
-        """Returns location codes from 960$t"""
+    @property
+    def audn(self) -> List[str]:
+        audns = [i[2].strip() for i in self.locs if len(i) >= 3]
+        return [i for i in audns if i]
+
+    @property
+    def branches(self) -> List[str]:
+        branches = [i[:2] for i in self.locs if len(i) >= 3]
+        return [i for i in branches if i]
+
+    @property
+    def copies(self) -> Optional[int]:
+        subfield = str(self._field.get(code="o"))
+        if subfield.isnumeric():
+            return int(subfield)
+        else:
+            return None
+
+    @property
+    def created(self) -> Optional[date]:
+        return normalize_date(self._field.get(code="q"))
+
+    @property
+    def form(self) -> Optional[str]:
+        subfield = str(self._field.get(code="g"))
+        if subfield and len(subfield) == 1:
+            return str(subfield)
+        else:
+            return None
+
+    @property
+    def lang(self) -> Optional[str]:
+        subfield = str(self._field.get(code="w"))
+        if subfield and len(subfield) == 3:
+            return subfield
+        else:
+            return None
+
+    @property
+    def locs(self) -> List[str]:
         locs = []
-        for sub in field.get_subfields("t"):
+        for sub in self._field.get_subfields("t"):
             try:
                 s = sub.index("(")
                 e = sub.index(")")
@@ -39,64 +71,31 @@ class Order:
                 locs.append(loc)
         return locs
 
-    def _get_venNotes(self, following_field: Optional[Field]) -> Optional[str]:
-        """
-        Returns vendor notes
-
-        Args:
-            following_field:
-                either an instance of pymarc.Field or None. This should
-                field that follows the 960 field used to instantiate an Order
-                object. If the 960 field was the last field in the record
-                then following_field is None.
-        Returns:
-            vendor note as a string or None if subfield h does not exist
-        """
-        if following_field and following_field.tag == "961":
-            venNotes: Optional[str] = following_field.get("h", None)
-            return venNotes
-        else:
+    @property
+    def oid(self) -> Optional[int]:
+        order_num = self._field.get(code="z")
+        if not order_num or str(order_num).isalpha():
             return None
-
-    def _normalize_order_number(self, field: Field) -> int:
-        """Normalizes Sierra order number"""
-        order_num = field.get(code="z")
-        if not order_num:
-            raise ValueError("Order field must contain an order number (960$z)")
-        return int(order_num[2:-1])
-
-    @property
-    def audn(self) -> List[str]:
-        audns = []
-        for loc in self.locs:
-            if len(loc) >= 3:
-                audn = loc[2].strip()
-            else:
-                audn = None
-            if audn:
-                audns.append(audn)
-        return audns
-
-    @property
-    def branches(self) -> List[str]:
-        branches = []
-        for loc in self.locs:
-            if len(loc) >= 3:
-                branch = loc[:2]
-            else:
-                branch = None
-            if branch:
-                branches.append(branch)
-        return branches
+        else:
+            return int(order_num[2:-1])
 
     @property
     def shelves(self) -> List[str]:
-        shelves = []
-        for loc in self.locs:
-            if len(loc) >= 5:
-                shelf = loc[3:5].strip()
-            else:
-                shelf = None
-            if shelf:
-                shelves.append(shelf)
-        return shelves
+        shelves = [i[3:5].strip() for i in self.locs if len(i) >= 5]
+        return [i for i in shelves if i]
+
+    @property
+    def status(self) -> Optional[str]:
+        subfield = str(self._field.get(code="m"))
+        if subfield and len(subfield) == 1:
+            return str(subfield)
+        else:
+            return None
+
+    @property
+    def venNotes(self) -> Optional[str]:
+        if self._following_field and self._following_field.tag == "961":
+            venNotes: Optional[str] = self._following_field.get("h", None)
+            return venNotes
+        else:
+            return None

--- a/bookops_marc/models.py
+++ b/bookops_marc/models.py
@@ -10,6 +10,34 @@ from pymarc import Field
 from .local_values import normalize_date
 
 
+class Item:
+    """
+    A class to represent an Item record
+    """
+
+    def __init__(self, field: Field) -> None:
+        self.agency = self._get_non_repeatable_subfield(field, "h")
+        self.barcode = self._get_non_repeatable_subfield(field, "i")
+        self.call_no = self._get_non_repeatable_subfield(field, "a")
+        self.call_tag = self._get_non_repeatable_subfield(field, "z")
+        self.item_id = self._get_non_repeatable_subfield(field, "y")
+        self.item_message = self._get_non_repeatable_subfield(field, "u")
+        self.location = self._get_non_repeatable_subfield(field, "l")
+        self.opac_message = self._get_non_repeatable_subfield(field, "m")
+        self.price = self._get_non_repeatable_subfield(field, "p")
+        self.type = self._get_non_repeatable_subfield(field, "t")
+        self.vendor_code = self._get_non_repeatable_subfield(field, "v")
+        self.volume = self._get_non_repeatable_subfield(field, "c")
+
+    def _get_non_repeatable_subfield(self, field: Field, code: str) -> Optional[str]:
+        subfields = field.get_subfields(code)
+        if len(subfields) > 1:
+            raise ValueError(f"Subfield {code} is non-repeatable.")
+        for subfield in subfields:
+            return subfield
+        return None
+
+
 class Order:
     """
     A class to represent an Order record

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,28 @@ def stub_961():
 
 
 @pytest.fixture
+def stub_945():
+    return Field(
+        tag="945",
+        indicators=Indicators(" ", " "),
+        subfields=[
+            Subfield(code="a", value="ReCAP 25-000001"),
+            Subfield(code="h", value="043"),
+            Subfield(code="i", value="33433123456789"),
+            Subfield(code="z", value="8528"),
+            Subfield(code="t", value="55"),
+            Subfield(code="u", value="foo"),
+            Subfield(code="m", value="bar"),
+            Subfield(code="l", value="rc2ma"),
+            Subfield(code="p", value="$5.00"),
+            Subfield(code="v", value="LEILA"),
+            Subfield(code="c", value="1"),
+            Subfield(code="y", value=".i123456789"),
+        ],
+    )
+
+
+@pytest.fixture
 def stub_field():
     return Field(
         tag="999",

--- a/tests/test_bib.py
+++ b/tests/test_bib.py
@@ -550,11 +550,11 @@ def test_oclc_nos_001_only(stub_bib):
 
 
 @pytest.mark.parametrize("arg", [1, "foo"])
-def test_orders_exceptions(arg, stub_bib, mock_960):
+def test_sort_orders_exceptions(arg, stub_bib, mock_960):
     msg = "Invalid 'sort' argument was passed."
     stub_bib.add_field(mock_960)
     with pytest.raises(BookopsMarcError) as exc:
-        stub_bib.orders(sort=arg)
+        stub_bib.sort_orders(sort=arg)
     assert msg in str(exc)
 
 
@@ -570,7 +570,7 @@ def test_orders_single(stub_bib, mock_960):
             ],
         )
     )
-    orders = stub_bib.orders()
+    orders = stub_bib.orders
     assert len(orders) == 1
     o = orders[0]
     assert o.oid == 1000001
@@ -602,7 +602,7 @@ def test_orders_reverse_sort(stub_bib, mock_960):
     second_960.delete_subfield("z")
     second_960.add_subfield("z", ".o10000020")
     stub_bib.add_field(second_960)
-    orders = stub_bib.orders(sort="descending")
+    orders = stub_bib.sort_orders(sort="descending")
 
     assert len(orders) == 2
     assert orders[0].oid == 1000002

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,46 +1,6 @@
 import datetime
 import pytest
-from bookops_marc.models import Item, Order
-
-
-def test_Item(stub_945):
-    item = Item(field=stub_945)
-    assert item.agency == "043"
-    assert item.barcode == "33433123456789"
-    assert item.call_no == "ReCAP 25-000001"
-    assert item.call_tag == "8528"
-    assert item.item_id == ".i123456789"
-    assert item.item_message == "foo"
-    assert item.location == "rc2ma"
-    assert item.opac_message == "bar"
-    assert item.price == "$5.00"
-    assert item.type == "55"
-    assert item.vendor_code == "LEILA"
-    assert item.volume == "1"
-
-
-def test_Item_missing_subfield(stub_945):
-    stub_945.delete_subfield("u")
-    item = Item(field=stub_945)
-    assert item.agency == "043"
-    assert item.barcode == "33433123456789"
-    assert item.call_no == "ReCAP 25-000001"
-    assert item.call_tag == "8528"
-    assert item.item_id == ".i123456789"
-    assert item.item_message is None
-    assert item.location == "rc2ma"
-    assert item.opac_message == "bar"
-    assert item.price == "$5.00"
-    assert item.type == "55"
-    assert item.vendor_code == "LEILA"
-    assert item.volume == "1"
-
-
-def test_Item_too_many_subfields(stub_945):
-    stub_945.add_subfield(code="i", value="33433111111111")
-    with pytest.raises(ValueError) as exc:
-        Item(stub_945)
-    assert str(exc.value) == "Subfield i is non-repeatable."
+from bookops_marc.models import Order
 
 
 def test_Order(mock_960, stub_961):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,30 +37,14 @@ def test_Order_other_following_field(mock_960, stub_field):
 @pytest.mark.parametrize(
     "arg,expectation",
     [
-        ("(3)sn", ["sn"]),
-        ("(2)btj0f", ["btj0f"]),
-        ("41anf(5)", ["41anf"]),
-        ("41anf", ["41anf"]),
-        ("(3)snj0y", ["snj0y"]),
+        ("41", []),
+        ("41anf", ["a"]),
+        ("snj0y", ["j"]),
+        ("sn   ", []),
         (None, []),
+        (" ", []),
+        ("      ", []),
     ],
-)
-def test_Order_locs(arg, expectation, stub_960, stub_961):
-    stub_960.delete_subfield("t")
-    stub_960.add_subfield(code="t", value=arg)
-    order = Order(field=stub_960, following_field=stub_961)
-    assert order.locs == expectation
-
-
-def test_Order_locs_no_location(stub_960, stub_961):
-    stub_960.delete_subfield("t")
-    order = Order(field=stub_960, following_field=stub_961)
-    assert order.locs == []
-
-
-@pytest.mark.parametrize(
-    "arg,expectation",
-    [("41", []), ("41anf", ["a"]), ("snj0y", ["j"]), ("sn   ", []), (None, [])],
 )
 def test_Order_audn(arg, expectation, stub_960, stub_961):
     stub_960.delete_subfield("t")
@@ -84,6 +68,8 @@ def test_Order_audn_no_location(stub_960, stub_961):
         ("fty0n", ["ft"]),
         ("0n", []),
         (None, []),
+        (" ", []),
+        ("", []),
     ],
 )
 def test_Order_branches(arg, expectation, stub_960, stub_961):
@@ -102,12 +88,179 @@ def test_Order_branches_no_location(stub_960, stub_961):
 @pytest.mark.parametrize(
     "arg,expectation",
     [
+        ("1", 1),
+        ("02", 2),
+        (2, 2),
+        ("fty0n", None),
+        ("0n", None),
+        (None, None),
+        (" ", None),
+        ("      ", None),
+        ("three", None),
+    ],
+)
+def test_Order_copies(arg, expectation, stub_960, stub_961):
+    stub_960.delete_subfield("o")
+    stub_960.add_subfield(code="o", value=arg)
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.copies == expectation
+
+
+def test_Order_copies_no_subfield(stub_960, stub_961):
+    stub_960.delete_subfield("o")
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.copies is None
+
+
+@pytest.mark.parametrize(
+    "arg,expectation",
+    [
+        ("01-01-24", datetime.date(2024, 1, 1)),
+        ("02-02-02", datetime.date(2002, 2, 2)),
+        ("02-02-2022", datetime.date(2022, 2, 2)),
+        ("foo", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_Order_created(arg, expectation, stub_960, stub_961):
+    stub_960.delete_subfield("q")
+    stub_960.add_subfield(code="q", value=arg)
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.created == expectation
+
+
+def test_Order_created_no_subfield(stub_960, stub_961):
+    stub_960.delete_subfield("q")
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.created is None
+
+
+@pytest.mark.parametrize(
+    "arg,expectation",
+    [
+        ("b", "b"),
+        ("a", "a"),
+        ("m", "m"),
+        ("p", "p"),
+        ("foo", None),
+        ("", None),
+        ("book", None),
+        ([], None),
+        (None, None),
+        (
+            (
+                "a",
+                "b",
+            ),
+            None,
+        ),
+    ],
+)
+def test_Order_form(arg, expectation, stub_960, stub_961):
+    stub_960.delete_subfield("g")
+    stub_960.add_subfield(code="g", value=arg)
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.form == expectation
+
+
+def test_Order_form_no_subfield(stub_960, stub_961):
+    stub_960.delete_subfield("g")
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.form is None
+
+
+@pytest.mark.parametrize(
+    "arg,expectation",
+    [
+        ("eng", "eng"),
+        ("pol", "pol"),
+        ("cze", "cze"),
+        ("spa", "spa"),
+        ("Spanish", None),
+        (1, None),
+        ("", None),
+        ([], None),
+        (None, None),
+        (
+            (
+                "spa",
+                "fre",
+            ),
+            None,
+        ),
+    ],
+)
+def test_Order_lang(arg, expectation, stub_960, stub_961):
+    stub_960.delete_subfield("w")
+    stub_960.add_subfield(code="w", value=arg)
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.lang == expectation
+
+
+def test_Order_lang_no_subfield(stub_960, stub_961):
+    stub_960.delete_subfield("w")
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.lang is None
+
+
+@pytest.mark.parametrize(
+    "arg,expectation",
+    [
+        ("(3)sn", ["sn"]),
+        ("(2)btj0f", ["btj0f"]),
+        ("41anf(5)", ["41anf"]),
+        ("41anf", ["41anf"]),
+        ("(3)snj0y", ["snj0y"]),
+        (None, []),
+    ],
+)
+def test_Order_locs(arg, expectation, stub_960, stub_961):
+    stub_960.delete_subfield("t")
+    stub_960.add_subfield(code="t", value=arg)
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.locs == expectation
+
+
+def test_Order_locs_no_location(stub_960, stub_961):
+    stub_960.delete_subfield("t")
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.locs == []
+
+
+@pytest.mark.parametrize(
+    "arg,expectation",
+    [
+        (".o28876714", 2887671),
+        (".o12345678", 1234567),
+        (".o10000000", 1000000),
+        (None, None),
+    ],
+)
+def test_Order_oid(arg, expectation, stub_960, stub_961):
+    stub_960.delete_subfield("z")
+    stub_960.add_subfield(code="z", value=arg)
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.oid == expectation
+
+
+def test_Order_oid_no_subfield(stub_960, stub_961):
+    stub_960.delete_subfield("z")
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.oid is None
+
+
+@pytest.mark.parametrize(
+    "arg,expectation",
+    [
         ("41anf", ["nf"]),
         ("13anb", ["nb"]),
         ("snj0f", ["0f"]),
         ("tb", []),
         ("tb   ", []),
         (None, []),
+        (" ", []),
+        ("      ", []),
     ],
 )
 def test_Order_shelves(arg, expectation, stub_960, stub_961):
@@ -126,21 +279,59 @@ def test_Order_shelves_no_location(stub_960, stub_961):
 @pytest.mark.parametrize(
     "arg,expectation",
     [
-        (".o28876714", 2887671),
-        (".o12345678", 1234567),
-        (".o10000000", 1000000),
+        ("2", "2"),
+        ("a", "a"),
+        ("o", "o"),
+        ("z", "z"),
+        ("foo", None),
+        ("", None),
+        ([], None),
+        (None, None),
+        (
+            (
+                "a",
+                "b",
+            ),
+            None,
+        ),
     ],
 )
-def test_Order_oid(arg, expectation, stub_960, stub_961):
-    stub_960.delete_subfield("z")
-    stub_960.add_subfield(code="z", value=arg)
+def test_Order_status(arg, expectation, stub_960, stub_961):
+    stub_960.delete_subfield("m")
+    stub_960.add_subfield(code="m", value=arg)
     order = Order(field=stub_960, following_field=stub_961)
-    assert order.oid == expectation
+    assert order.status == expectation
 
 
-def test_Order_missing_order_number(stub_960, stub_961):
-    stub_960.delete_subfield("z")
-    stub_960.add_subfield(code="z", value=None)
-    with pytest.raises(ValueError) as exc:
-        Order(field=stub_960, following_field=stub_961)
-    assert str(exc.value) == "Order field must contain an order number (960$z)"
+def test_Order_status_no_subfield(stub_960, stub_961):
+    stub_960.delete_subfield("m")
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.status is None
+
+
+@pytest.mark.parametrize(
+    "arg,expectation",
+    [
+        ("foo", "foo"),
+        ("bar", "bar"),
+        ("baz", "baz"),
+        ("", ""),
+        (None, None),
+    ],
+)
+def test_Order_venNotes(arg, expectation, stub_960, stub_961):
+    stub_961.delete_subfield("h")
+    stub_961.add_subfield(code="h", value=arg)
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.venNotes == expectation
+
+
+def test_Order_venNotes_no_subfield(stub_960, stub_961):
+    stub_961.delete_subfield("h")
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.venNotes is None
+
+
+def test_Order_venNotes_no_961(stub_960):
+    order = Order(field=stub_960, following_field=None)
+    assert order.venNotes is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,46 @@
 import datetime
 import pytest
-from bookops_marc.models import Order
+from bookops_marc.models import Item, Order
+
+
+def test_Item(stub_945):
+    item = Item(field=stub_945)
+    assert item.agency == "043"
+    assert item.barcode == "33433123456789"
+    assert item.call_no == "ReCAP 25-000001"
+    assert item.call_tag == "8528"
+    assert item.item_id == ".i123456789"
+    assert item.item_message == "foo"
+    assert item.location == "rc2ma"
+    assert item.opac_message == "bar"
+    assert item.price == "$5.00"
+    assert item.type == "55"
+    assert item.vendor_code == "LEILA"
+    assert item.volume == "1"
+
+
+def test_Item_missing_subfield(stub_945):
+    stub_945.delete_subfield("u")
+    item = Item(field=stub_945)
+    assert item.agency == "043"
+    assert item.barcode == "33433123456789"
+    assert item.call_no == "ReCAP 25-000001"
+    assert item.call_tag == "8528"
+    assert item.item_id == ".i123456789"
+    assert item.item_message is None
+    assert item.location == "rc2ma"
+    assert item.opac_message == "bar"
+    assert item.price == "$5.00"
+    assert item.type == "55"
+    assert item.vendor_code == "LEILA"
+    assert item.volume == "1"
+
+
+def test_Item_too_many_subfields(stub_945):
+    stub_945.add_subfield(code="i", value="33433111111111")
+    with pytest.raises(ValueError) as exc:
+        Item(stub_945)
+    assert str(exc.value) == "Subfield i is non-repeatable."
 
 
 def test_Order(mock_960, stub_961):


### PR DESCRIPTION
Changed
 - `README` to reflect changes made in releases/v0.11.0 branch
 - `Bib.orders` is now a property
 - all `Order` properties are now read only

Added
 - `Bib.sort_orders()` method to retain order sorting functionality previously in `Bib.orders()` method
 - `TypeError` handling to `normalize_date()` function