### PR TITLE
Call number and collection updates

### DIFF
--- a/bookops_marc/bib.py
+++ b/bookops_marc/bib.py
@@ -349,25 +349,21 @@ class Bib(Record):
         return self.leader[6]
 
     @property
-    def research_call_no(self) -> Optional[str]:
+    def research_call_no(self) -> List[str]:
         """
         Retrieves research library call number as string without any MARC coding
         """
-        field = self.research_call_no_field
-        if field:
-            return field.value()
-        else:
-            return None
+        return [i.value() for i in self.research_call_no_field if i]
 
     @property
-    def research_call_no_field(self) -> Optional[Field]:
+    def research_call_no_field(self) -> List[Field]:
         """
         Retrieves a research library call number field as pymarc.Field instance
         """
+        fields = []
         if self.library == "nypl":
-            return self.get("852")
-        else:
-            return None
+            fields.extend(self.get_fields("852"))
+        return fields
 
     @property
     def sierra_bib_format(self) -> Optional[str]:

--- a/bookops_marc/bib.py
+++ b/bookops_marc/bib.py
@@ -114,7 +114,7 @@ class Bib(Record):
         """
         if not self.library == "nypl":
             return None
-        subfields = [i.get("a") for i in self.get_fields("910") if i]
+        subfields = [i.get("a").strip() for i in self.get_fields("910") if i]
         if len(subfields) == 1 and subfields[0] in ["BL", "RL"]:
             return str(subfields[0])
         elif sorted(subfields) == ["BL", "RL"]:

--- a/bookops_marc/bib.py
+++ b/bookops_marc/bib.py
@@ -102,6 +102,27 @@ class Bib(Record):
             return None
 
     @property
+    def collection(self) -> Optional[str]:
+        """
+        Returns the collection that the record is a part of.
+
+        Options are "RL" (for research materials), "BL" (for branch materials),
+        "mixed", or None. An NYPL record will have the collection "RL" or "BL" if the
+        record contains one 910$a field with the value "RL" or "BL". If an NYPL record
+        contains two 910$a fields and both "BL" and "RL", the record's collection will
+        be "mixed". All other records will be assigned `None` as the collection type.
+        """
+        if not self.library == "nypl":
+            return None
+        subfields = [i.get("a") for i in self.get_fields("910") if i]
+        if len(subfields) == 1 and subfields[0] in ["BL", "RL"]:
+            return str(subfields[0])
+        elif sorted(subfields) == ["BL", "RL"]:
+            return "mixed"
+        else:
+            return None
+
+    @property
     def control_number(self) -> Optional[str]:
         """
         Returns a control number from the 001 tag if it exists.
@@ -326,6 +347,27 @@ class Bib(Record):
         Retrieves record type code from MARC leader
         """
         return self.leader[6]
+
+    @property
+    def research_call_no(self) -> Optional[str]:
+        """
+        Retrieves research library call number as string without any MARC coding
+        """
+        field = self.research_call_no_field
+        if field:
+            return field.value()
+        else:
+            return None
+
+    @property
+    def research_call_no_field(self) -> Optional[Field]:
+        """
+        Retrieves a research library call number field as pymarc.Field instance
+        """
+        if self.library == "nypl":
+            return self.get("852")
+        else:
+            return None
 
     @property
     def sierra_bib_format(self) -> Optional[str]:

--- a/tests/test_bib.py
+++ b/tests/test_bib.py
@@ -1041,16 +1041,46 @@ def test_Bib_classmethod_pymarc_record_to_local_bib_invalid(mock_960, arg):
 @pytest.mark.parametrize(
     "arg1,arg2,expectation",
     [
-        ("bpl", "099", None),
-        ("bpl", "852", None),
-        ("nypl", "852", "ReCAP 25-000001"),
-        ("nypl", "099", None),
-        ("nypl", "091", None),
-        ("", "852", None),
+        ("bpl", "099", []),
+        ("bpl", "852", []),
+        ("nypl", "852", ["ReCAP 25-000001"]),
+        ("nypl", "099", []),
+        ("nypl", "091", []),
+        ("", "852", []),
     ],
 )
 def test_research_call_no(stub_bib, arg1, arg2, expectation):
     stub_bib.library = arg1
+    stub_bib.add_field(
+        Field(
+            tag=arg2,
+            indicators=Indicators(" ", " "),
+            subfields=[Subfield(code="h", value="ReCAP 25-000001")],
+        )
+    )
+    assert stub_bib.research_call_no == expectation
+
+
+@pytest.mark.parametrize(
+    "arg1,arg2,expectation",
+    [
+        ("bpl", "099", []),
+        ("bpl", "852", []),
+        ("nypl", "852", ["Foo", "ReCAP 25-000001"]),
+        ("nypl", "099", []),
+        ("nypl", "091", []),
+        ("", "852", []),
+    ],
+)
+def test_research_call_no_multiple(stub_bib, arg1, arg2, expectation):
+    stub_bib.library = arg1
+    stub_bib.add_field(
+        Field(
+            tag=arg2,
+            indicators=Indicators(" ", " "),
+            subfields=[Subfield(code="h", value="Foo")],
+        )
+    )
     stub_bib.add_field(
         Field(
             tag=arg2,
@@ -1097,22 +1127,22 @@ def test_collection(stub_bib, arg1, arg2, expectation):
 @pytest.mark.parametrize(
     "library,colls,call_tag,bl_call_no,rl_call_no,coll",
     [
-        ("bpl", [], "091", None, None, None),
-        ("bpl", ["BL"], "091", None, None, None),
-        ("bpl", ["RL"], "091", None, None, None),
-        ("bpl", ["BL", "RL"], "091", None, None, None),
-        ("bpl", [], "099", "FIC FOO", None, None),
-        ("bpl", ["BL"], "099", "FIC FOO", None, None),
-        ("bpl", ["RL"], "099", "FIC FOO", None, None),
-        ("bpl", ["BL", "RL"], "099", "FIC FOO", None, None),
-        ("nypl", [], "091", "FIC FOO", "ReCAP 25-000001", None),
-        ("nypl", ["BL"], "091", "FIC FOO", "ReCAP 25-000001", "BL"),
-        ("nypl", ["RL"], "091", "FIC FOO", "ReCAP 25-000001", "RL"),
-        ("nypl", ["BL", "RL"], "091", "FIC FOO", "ReCAP 25-000001", "mixed"),
-        ("nypl", [], "099", None, "ReCAP 25-000001", None),
-        ("nypl", ["BL"], "099", None, "ReCAP 25-000001", "BL"),
-        ("nypl", ["RL"], "099", None, "ReCAP 25-000001", "RL"),
-        ("nypl", ["BL", "RL"], "099", None, "ReCAP 25-000001", "mixed"),
+        ("bpl", [], "091", None, [], None),
+        ("bpl", ["BL"], "091", None, [], None),
+        ("bpl", ["RL"], "091", None, [], None),
+        ("bpl", ["BL", "RL"], "091", None, [], None),
+        ("bpl", [], "099", "FIC FOO", [], None),
+        ("bpl", ["BL"], "099", "FIC FOO", [], None),
+        ("bpl", ["RL"], "099", "FIC FOO", [], None),
+        ("bpl", ["BL", "RL"], "099", "FIC FOO", [], None),
+        ("nypl", [], "091", "FIC FOO", ["ReCAP 25-000001"], None),
+        ("nypl", ["BL"], "091", "FIC FOO", ["ReCAP 25-000001"], "BL"),
+        ("nypl", ["RL"], "091", "FIC FOO", ["ReCAP 25-000001"], "RL"),
+        ("nypl", ["BL", "RL"], "091", "FIC FOO", ["ReCAP 25-000001"], "mixed"),
+        ("nypl", [], "099", None, ["ReCAP 25-000001"], None),
+        ("nypl", ["BL"], "099", None, ["ReCAP 25-000001"], "BL"),
+        ("nypl", ["RL"], "099", None, ["ReCAP 25-000001"], "RL"),
+        ("nypl", ["BL", "RL"], "099", None, ["ReCAP 25-000001"], "mixed"),
     ],
 )
 def test_collection_call_no_combos(

--- a/tests/test_bib.py
+++ b/tests/test_bib.py
@@ -1067,9 +1067,12 @@ def test_research_call_no(stub_bib, arg1, arg2, expectation):
         ("bpl", ["BL"], None),
         ("bpl", ["RL"], None),
         ("bpl", [], None),
-        ("bpl", ["BL", "RL"], None),
+        ("bpl", ["   BL", "RL   "], None),
         ("nypl", ["BL"], "BL"),
+        ("nypl", ["   BL   "], "BL"),
         ("nypl", ["RL"], "RL"),
+        ("nypl", ["   RL    "], "RL"),
+        ("nypl", ["BL  ", "  RL"], "mixed"),
         ("nypl", ["BL", "RL"], "mixed"),
         ("nypl", [], None),
         ("nypl", ["foo"], None),
@@ -1092,7 +1095,7 @@ def test_collection(stub_bib, arg1, arg2, expectation):
 
 
 @pytest.mark.parametrize(
-    "library,colls,call_tag,bl_call_no,rl_call_no,collection",
+    "library,colls,call_tag,bl_call_no,rl_call_no,coll",
     [
         ("bpl", [], "091", None, None, None),
         ("bpl", ["BL"], "091", None, None, None),

--- a/tests/test_bib.py
+++ b/tests/test_bib.py
@@ -1089,3 +1089,58 @@ def test_collection(stub_bib, arg1, arg2, expectation):
             )
         )
     assert stub_bib.collection == expectation
+
+
+@pytest.mark.parametrize(
+    "library,colls,call_tag,bl_call_no,rl_call_no,collection",
+    [
+        ("bpl", [], "091", None, None, None),
+        ("bpl", ["BL"], "091", None, None, None),
+        ("bpl", ["RL"], "091", None, None, None),
+        ("bpl", ["BL", "RL"], "091", None, None, None),
+        ("bpl", [], "099", "FIC FOO", None, None),
+        ("bpl", ["BL"], "099", "FIC FOO", None, None),
+        ("bpl", ["RL"], "099", "FIC FOO", None, None),
+        ("bpl", ["BL", "RL"], "099", "FIC FOO", None, None),
+        ("nypl", [], "091", "FIC FOO", "ReCAP 25-000001", None),
+        ("nypl", ["BL"], "091", "FIC FOO", "ReCAP 25-000001", "BL"),
+        ("nypl", ["RL"], "091", "FIC FOO", "ReCAP 25-000001", "RL"),
+        ("nypl", ["BL", "RL"], "091", "FIC FOO", "ReCAP 25-000001", "mixed"),
+        ("nypl", [], "099", None, "ReCAP 25-000001", None),
+        ("nypl", ["BL"], "099", None, "ReCAP 25-000001", "BL"),
+        ("nypl", ["RL"], "099", None, "ReCAP 25-000001", "RL"),
+        ("nypl", ["BL", "RL"], "099", None, "ReCAP 25-000001", "mixed"),
+    ],
+)
+def test_collection_call_no_combos(
+    stub_bib, library, colls, call_tag, bl_call_no, rl_call_no, coll
+):
+    stub_bib.library = library
+    for value in colls:
+        stub_bib.add_field(
+            Field(
+                tag="910",
+                indicators=Indicators(" ", " "),
+                subfields=[Subfield(code="a", value=value)],
+            )
+        )
+    stub_bib.add_field(
+        Field(
+            tag=call_tag,
+            indicators=Indicators(" ", " "),
+            subfields=[
+                Subfield(code="a", value="FIC"),
+                Subfield(code="a", value="FOO"),
+            ],
+        )
+    )
+    stub_bib.add_field(
+        Field(
+            tag="852",
+            indicators=Indicators(" ", " "),
+            subfields=[Subfield(code="h", value="ReCAP 25-000001")],
+        )
+    )
+    assert stub_bib.branch_call_no == bl_call_no
+    assert stub_bib.research_call_no == rl_call_no
+    assert stub_bib.collection == coll


### PR DESCRIPTION
## Added
Added `Bib.collection`, `Bib.research_call_no_field` and `Bib.research_call_no` properties. All `Bib` objects will have these properties but these properties will be `None` in many cases. 

## `collection`: 
 - Possible values are "BL", "RL", "mixed" and `None`
 - The `collection` will be "BL"or "RL" if `Bib.library` is "nypl" and the record contains exactly one 910$a with the value "BL" or "RL"
 - The `collection` will be "mixed" if `Bib.library` is "nypl" and the record has 910$a fields with both "BL" and "RL". The `Bib` must have exactly two 910$a fields
 - `Bib.collection` will be `None` for all other records

## `research_call_no_field` and `research_call_no`:
 - Following the logic from `branch_call_no_field`, the `research_call_no_field` retrieves a field based on the `Bib.library` attribute. For nypl records the 852 field is retrieved. The value will be `None` for all other records for both `research_call_no` and `research_call_no_field`.
 - These properties do not check the `Bib.collection` property first which means:
   - it is possible for a `Bib` to have values for both `research_call_no` and `branch_call_no`
   - it is possible for a branch `Bib` to have a `research_call_no` and no `branch_call_no`
   - it is possible for a research `Bib` to have a `branch_call_no` and no `research_call_no`

@klinga, let me know what you think of this approach.