### PR TITLE
Order id changes

### DIFF
--- a/bookops_marc/models.py
+++ b/bookops_marc/models.py
@@ -129,6 +129,8 @@ class Order:
             the language of the materials being ordered from subfield 'w'.
         locs:
             a list of location codes from subfield 't'
+        order_id:
+            the order id as a string from subfield 'z' removes "." prefix.
         order_id_normalized:
             the normalized order id as an integer from subfield 'z'.
             removes ".o" prefix and check digit.
@@ -213,12 +215,20 @@ class Order:
         return locs
 
     @property
-    def order_id_normalized(self) -> Optional[int]:
-        order_num = self._field.get(code="z")
-        if not order_num or str(order_num).isalpha():
-            return None
+    def order_id(self) -> Optional[str]:
+        order_id = self._field.get(code="z")
+        if isinstance(order_id, str) and len(order_id) > 1:
+            return order_id.strip()[1:]
         else:
-            return int(order_num[2:-1])
+            return None
+
+    @property
+    def order_id_normalized(self) -> Optional[int]:
+        order_id = self.order_id
+        if isinstance(order_id, str) and order_id[1:].isnumeric():
+            return int(order_id[1:-1])
+        else:
+            return None
 
     @property
     def shelves(self) -> List[str]:

--- a/tests/test_bib.py
+++ b/tests/test_bib.py
@@ -581,6 +581,7 @@ def test_orders_single(stub_bib, mock_960):
     orders = stub_bib.orders
     assert len(orders) == 1
     o = orders[0]
+    assert o.order_id == "o10000010"
     assert o.order_id_normalized == 1000001
     assert o.audn == ["j", "j", "j", "j"]
     assert o.status == "o"
@@ -613,8 +614,10 @@ def test_orders_reverse_sort(stub_bib, mock_960):
     orders = stub_bib.sort_orders(sort="descending")
 
     assert len(orders) == 2
+    assert orders[0].order_id == "o10000020"
     assert orders[0].order_id_normalized == 1000002
     assert orders[0].venNotes is None
+    assert orders[1].order_id == "o10000010"
     assert orders[1].order_id_normalized == 1000001
     assert orders[1].venNotes == "e,bio"
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -155,6 +155,7 @@ def test_Order(mock_960, stub_961):
     assert order.form == "b"
     assert order.lang == "eng"
     assert order.locs == ["snj0y", "agj0y", "muj0y", "inj0y"]
+    assert order.order_id == "o10000010"
     assert order.order_id_normalized == 1000001
     assert order.shelves == ["0y", "0y", "0y", "0y"]
     assert order.status == "o"
@@ -171,6 +172,7 @@ def test_Order_other_following_field(mock_960, stub_field):
     assert order.form == "b"
     assert order.lang == "eng"
     assert order.locs == ["snj0y", "agj0y", "muj0y", "inj0y"]
+    assert order.order_id == "o10000010"
     assert order.order_id_normalized == 1000001
     assert order.shelves == ["0y", "0y", "0y", "0y"]
     assert order.status == "o"
@@ -369,6 +371,28 @@ def test_Order_locs_no_location(stub_960, stub_961):
     stub_960.delete_subfield("t")
     order = Order(field=stub_960, following_field=stub_961)
     assert order.locs == []
+
+
+@pytest.mark.parametrize(
+    "arg,expectation",
+    [
+        (".o28876714", "o28876714"),
+        (".o12345678", "o12345678"),
+        (".o10000000", "o10000000"),
+        (None, None),
+    ],
+)
+def test_Order_order_id(arg, expectation, stub_960, stub_961):
+    stub_960.delete_subfield("z")
+    stub_960.add_subfield(code="z", value=arg)
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.order_id == expectation
+
+
+def test_Order_order_id_no_subfield(stub_960, stub_961):
+    stub_960.delete_subfield("z")
+    order = Order(field=stub_960, following_field=stub_961)
+    assert order.order_id is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Added
 - `Order.order_id` property which retains order ID as a string with its "o" prefix and check digit.  

Changed
 - `Order.oid` is now `Order.order_id_normalized`. This follows the pattern used in the `Bib` class for `sierra_bib_id` and `sierra_bib_id_normalized`